### PR TITLE
Bugfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "style-loader": "*",
     "url-loader": "^0.5.5",
     "webpack": "^1.4.9",
-    "webpack-core": "^0.4.8"
+    "webpack-core": "^0.4.8",
+    "webpack-dev-server": "~1.7.0"
   },
   "browser": {
     "fs": false

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,7 +45,7 @@ module.exports = {
       },
       {
         // required for bootstrap icons
-        test: /\.woff(\?(.*))?$/,
+        test: /\.(woff|woff2)(\?(.*))?$/,
         loader: 'url?prefix=factorynts/&limit=5000&mimetype=application/font-woff'
       },
       {


### PR DESCRIPTION
gulp serve couldn't be started because webpack-dev-server was missing
bootstrap-sass-official includes woff2 glyphicons, but they were not being processed by webpack and causing an Unexpected token ILLEGAL error